### PR TITLE
Update DynamsoftCameraView.tsx

### DIFF
--- a/js/DynamsoftCameraView.tsx
+++ b/js/DynamsoftCameraView.tsx
@@ -43,7 +43,7 @@ interface Props extends ViewProps {
     torchButton?: TorchButton
 }
 
-const DCEView: HostComponent<any> = requireNativeComponent('DYSCameraView');
+const DCEView: HostComponent<any> = requireNativeComponent<any>('DYSCameraView');
 
 const mapValues = (input: any, mapper: any) => {
     const result:any = {};


### PR DESCRIPTION
tsc throws below error. this could be fixed by adding an <any> in requireNativeComponent. Issue is reproducible in tsc version 4.9.5

```
 Type 'ComponentType<any>' is not assignable to type 'HostComponent<any>'.
  Type 'ComponentClass<any, any>' is not assignable to type 'HostComponent<any>'.
    Type 'Component<any, any, any>' is not assignable to type 'Component<any, {}, any> & Readonly<NativeMethods>'.
      Type 'Component<any, any, any>' is missing the following properties from type 'Readonly<NativeMethods>': measure, measureInWindow, measureLayout, setNativeProps, and 2 more.

```